### PR TITLE
Added -h as a default help flag

### DIFF
--- a/src/java/com/martiansoftware/jsap/SimpleJSAP.java
+++ b/src/java/com/martiansoftware/jsap/SimpleJSAP.java
@@ -71,7 +71,7 @@ public class SimpleJSAP extends JSAP {
 		this.name = name;
 		this.explanation = explanation;
 		
-		final Switch help = new Switch( "help", JSAP.NO_SHORTFLAG, "help" );
+		final Switch help = new Switch( "help", 'h', "help" );
 		help.setHelp( "Prints this help message." );
 		this.registerParameter( help );
 


### PR DESCRIPTION
IMO, every program should have both --help and -h as standard help options.  It's a pain using the wrong one and having to try again; makes me kinda sigh and roll my eyes; and since we didn't collectively manage to standardize on one of the two, we're kinda stuck with both.

Also, btw, I tried three command line parsing libraries, and this one won; so thanks