### PR TITLE
Create implementaion of StringParser for parsing Enum values

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -279,7 +279,7 @@ Targets:
 		<delete dir="${distimage}" />
 		<mkdir dir="${distimage}" />
 		<copy todir="${distimage}" file="${buildfile}" />
-		<copy todir="${distimage}" file="LICENSE.TXT" />
+		<copy todir="${distimage}" file="LICENSE-2.0.txt" />
 		<copy todir="${distimage}" file="src/doc/CHANGELOG.TXT" />
 
 		<!-- copy source files into temp directory -->

--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,7 @@ Author:
  http://www.martiansoftware.com/contact.html
 
 Legal:
- Copyright (C) 2002-2021, Martian Software, Inc.
+ Copyright (C) 2002-2023, Martian Software, Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ Legal:
 
 	<!-- Basics -->
 	<property name="name" value="jsap" />
-	<property name="version" value="2.2"/>
-	<property name="year" value="2002-2020"/>
+	<property name="version" value="2.2.1"/>
+	<property name="year" value="2002-2023"/>
 
 	<property name="build.sysclasspath" value="ignore"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>jsap</artifactId>
   <packaging>jar</packaging>
   <name>JSAP</name>
-  <version>2.2</version>
+  <version>2.2.1</version>
   <description>The Java-based Simple Argument Parser.</description>
   <url>http://www.martiansoftware.com/jsap/</url>
   <licenses>

--- a/src/java/com/martiansoftware/jsap/stringparsers/EnumStringParser.java
+++ b/src/java/com/martiansoftware/jsap/stringparsers/EnumStringParser.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2002-2021, Martian Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.martiansoftware.jsap.stringparsers;
+
+import com.martiansoftware.jsap.ParseException;
+import com.martiansoftware.jsap.StringParser;
+
+/**
+ * A {@link com.martiansoftware.jsap.StringParser} that enforces valid {@link Enum} entries.
+ *
+ * @param <E> type of the enum to enforce
+ */
+public class EnumStringParser<E extends Enum<E>> extends StringParser {
+
+    /**
+     *  Class instance of the Enum class to enforce.
+     */
+    private final Class<E> clazz;
+
+    /**
+     * Construct a new instance of the EnumStringParser for the given kind of {@link Enum}.
+     *
+     * @param enumClass enum that should be parsed
+     */
+    private EnumStringParser(final Class<E> enumClass) {
+        if (!enumClass.isEnum()) {
+            throw new IllegalArgumentException("Given class does not represent an enum: " + enumClass);
+        }
+        this.clazz = enumClass;
+    }
+
+    /**
+     * Create a {@link StringParser} that parses {@link Enum} values.
+     *
+     * @param enumClass enum to parse
+     * @return a StringParser parsing the enum
+     * @param <E> enum type that should be parsed
+     * @throws IllegalArgumentException if the provided type is not an Enum
+     */
+    public static <E extends Enum<E>> EnumStringParser<E> getParser(final Class<E> enumClass) throws IllegalArgumentException {
+        return new EnumStringParser<>(enumClass);
+    }
+
+    @Override
+    public E parse(final String optionValue) throws ParseException {
+        if (optionValue == null) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(clazz, optionValue);
+        } catch (IllegalArgumentException exception) {
+            throw new ParseException("Option has wrong value '" + optionValue + "'; valid values are: " + String.join(", ", validEnumValues()), exception);
+        }
+    }
+
+    /**
+     * Get a string array of all enum value names of the enum type that is parsed by this StringParser.
+     *
+     * @return array of valid enum values
+     */
+    private String[] validEnumValues() {
+        final E[] possibleEnumConstants = clazz.getEnumConstants();
+        final String[] validValues = new String[possibleEnumConstants.length];
+        for (int index = 0; index < possibleEnumConstants.length; index++) {
+            validValues[index] = possibleEnumConstants[index].toString();
+        }
+        return validValues;
+    }
+}

--- a/src/java/com/martiansoftware/jsap/stringparsers/EnumStringParser.java
+++ b/src/java/com/martiansoftware/jsap/stringparsers/EnumStringParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2021, Martian Software, Inc.
+ * Copyright (C) 2002-2023, Martian Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class EnumStringParser<E extends Enum<E>> extends StringParser {
         try {
             return Enum.valueOf(clazz, optionValue);
         } catch (IllegalArgumentException exception) {
-            throw new ParseException("Option has wrong value '" + optionValue + "'; valid values are: " + String.join(", ", validEnumValues()), exception);
+            throw new ParseException("Invalid option value '" + optionValue + "'; valid values are: " + String.join(", ", validEnumValues()), exception);
         }
     }
 


### PR DESCRIPTION
**Disclaimer**: The code in my PR is using Java 1.8 API (just `String.join()`) and `Enum`s were added in Java 1.5, but the JSAP version currently published on maven central (2.1) was compiled for Java 1.4, so this PR will break compatibility either way!

I've written this EnumParser and thought that it is a nice addition to the Parsers available by default. Please let me know if you would consider merging it given the disclaimer above. If so I'd be ready to put in the effort to make it Java 5 compatible at least, the initial variant is more a proof-of-concept taken from my (Java 17 based) project that is using it.